### PR TITLE
Feat/create aid

### DIFF
--- a/src/components/createIdentifierCard.tsx
+++ b/src/components/createIdentifierCard.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from "react";
+import { Loader } from "@components/loader";
+
+export function CreateIdentifierCard(props): JSX.Element {
+  const [name, setName] = useState("");
+  const [nameError, setNameError] = useState("");
+
+  useEffect(() => {
+    setNameError(props.error);
+  }, [props.error]);
+  const onBlurName = () => {
+    if (!name) {
+      setNameError("Name can not be empty");
+    } else {
+      setNameError("");
+    }
+  };
+
+  const onCreateIdentifier = async () => {
+    let hasError = false;
+    if (!name) {
+      setNameError("Name can not be empty");
+      hasError = true;
+    }
+    props.handleCreateIdentifier(name);
+  };
+
+  return (
+    <>
+      <div className=" max-w-xs m-4 flex flex-col gap-y-4">
+        <div>
+          <input
+            type="text"
+            id="vendor_url"
+            className={`bg-gray-50 border text-black border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 ${
+              nameError ? " text-red border-red" : ""
+            } `}
+            placeholder="Enter unique name for identifier"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={onBlurName}
+          />
+          {nameError ? <p className="text-red">{nameError}</p> : null}
+        </div>
+        <div className=" flex flex-row justify-center mt-2">
+          <button
+            type="button"
+            onClick={onCreateIdentifier}
+            className="text-white bg-green flex flex-row gap-x-1 font-medium rounded-full text-sm px-5 py-2 text-center"
+          >
+            {props.isLoading ? <Loader size={4} /> : null}
+            <p className="font-medium text-md">Create</p>
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/createIdentifierCard.tsx
+++ b/src/components/createIdentifierCard.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { isValidElement, useState, useEffect } from "react";
+import { hasWhiteSpace, removeWhiteSpace } from "@pages/background/utils";
 import { Loader } from "@components/loader";
 
 export function CreateIdentifierCard(props): JSX.Element {
@@ -16,13 +17,31 @@ export function CreateIdentifierCard(props): JSX.Element {
     }
   };
 
+  const handleRemoveWhiteSpace = () => {
+    setName(removeWhiteSpace(name));
+    setNameError("");
+  };
   const onCreateIdentifier = async () => {
     let hasError = false;
     if (!name) {
       setNameError("Name can not be empty");
       hasError = true;
+    } else if (hasWhiteSpace(name)) {
+      setNameError(
+        <div className="text-red mt-1">
+          No white spaces allowed.{" "}
+          <button
+            className=" underline cursor-pointer"
+            onClick={handleRemoveWhiteSpace}
+          >
+            click to remove
+          </button>
+        </div>
+      );
+      hasError = true;
     }
-    props.handleCreateIdentifier(name);
+
+    if (!hasError) props.handleCreateIdentifier(name);
   };
 
   return (
@@ -41,7 +60,13 @@ export function CreateIdentifierCard(props): JSX.Element {
             onChange={(e) => setName(e.target.value)}
             onBlur={onBlurName}
           />
-          {nameError ? <p className="text-red">{nameError}</p> : null}
+          {nameError ? (
+            isValidElement(nameError) ? (
+              nameError
+            ) : (
+              <p className="text-red mt-1">{nameError}</p>
+            )
+          ) : null}
         </div>
         <div className=" flex flex-row justify-center mt-2">
           <button

--- a/src/components/drawer.tsx
+++ b/src/components/drawer.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+export const Drawer = ({ children, isOpen, handleClose, header }) => {
+  return (
+    <div
+      className={
+        " fixed overflow-hidden z-50 bg-gray-dark bg-opacity-25 inset-0 transform ease-in-out " +
+        (isOpen
+          ? " transition-opacity opacity-100 duration-500 translate-x-0  "
+          : " transition-all delay-500 opacity-0 translate-x-full  ")
+      }
+    >
+      <section
+        className={
+          "rounded-bl-2xl rounded-tl-2xl border-t border-l border-b border-t-white border-b-white border-l-white w-screen max-w-xs right-0 absolute bg-gray-dark h-full shadow-xl delay-400 duration-500 ease-in-out transition-all transform  " +
+          (isOpen ? " translate-x-0 " : " translate-x-full ")
+        }
+      >
+        <article className="relative w-screen max-w-xs pb-10 flex flex-col space-y-6 overflow-y-scroll h-full">
+          <header className="p-4 font-bold text-lg ">{header}</header>
+          {children}
+        </article>
+      </section>
+      <section
+        className=" w-screen h-full cursor-pointer "
+        onClick={handleClose}
+      ></section>
+    </div>
+  );
+};

--- a/src/components/identifierList.tsx
+++ b/src/components/identifierList.tsx
@@ -1,25 +1,55 @@
 import { useState, useEffect } from "react";
 import { IdentifierCard } from "@components/identifierCard";
+import { Drawer } from "@components/drawer";
 import { Loader } from "@components/loader";
 import { IMessage } from "@pages/background/types";
+import { CreateIdentifierCard } from "@components/createIdentifierCard";
 
 export function IdentifierList(): JSX.Element {
   const [aids, setAids] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [showDrawer, setShowDrawer] = useState(false);
+  const [errCreate, setErrCreate] = useState("");
+
   const fetchIdentifiers = async () => {
-    setIsLoading(true);
     const { data } = await chrome.runtime.sendMessage<IMessage<void>>({
       type: "fetch-resource",
       subtype: "identifiers",
     });
-    console.log("data", data);
     setAids(data.aids);
+  };
+
+  const initialFetchIdentifiers = async () => {
+    setIsLoading(true);
+    fetchIdentifiers();
     setIsLoading(false);
   };
 
+  const refetchIdentifiers = async () => {
+    await fetchIdentifiers();
+    setShowDrawer(false);
+  };
+
   useEffect(() => {
-    fetchIdentifiers();
+    initialFetchIdentifiers();
   }, []);
+
+  const handleCreateIdentifier = async (name) => {
+    setIsCreating(true);
+    const { data, error } = await chrome.runtime.sendMessage<IMessage<void>>({
+      type: "create-resource",
+      subtype: "identifier",
+      data: { name },
+    });
+    if (error) {
+      setErrCreate(error?.message);
+    } else {
+      await refetchIdentifiers();
+      setErrCreate("");
+    }
+    setIsCreating(false);
+  };
 
   return (
     <>
@@ -28,6 +58,26 @@ export function IdentifierList(): JSX.Element {
           <Loader size={6} />
         </div>
       ) : null}
+      <div className=" flex flex-row-reverse">
+        <button
+          type="button"
+          onClick={() => setShowDrawer(true)}
+          className="text-white bg-green font-medium rounded-full text-xs px-2 py-1 text-center"
+        >
+          {"+ Create New"}
+        </button>
+      </div>
+      <Drawer
+        isOpen={showDrawer}
+        handleClose={() => setShowDrawer(false)}
+        header="Create Identifier"
+      >
+        <CreateIdentifierCard
+          isLoading={isCreating}
+          handleCreateIdentifier={handleCreateIdentifier}
+          error={errCreate}
+        />
+      </Drawer>
       {aids.map((aid, index) => (
         <div key={index} className="my-2 mx-4">
           <IdentifierCard aid={aid} />

--- a/src/components/selectCredential.tsx
+++ b/src/components/selectCredential.tsx
@@ -1,15 +1,19 @@
 import { useState, useEffect } from "react";
 import { CredentialCard } from "@components/credentialCard";
+import { Loader } from "@components/loader";
 import { IMessage } from "@pages/background/types";
 
 export function SelectCredential(): JSX.Element {
   const [credentials, setCredentials] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
   const fetchCredentials = async () => {
+    setIsLoading(true);
     const { data } = await chrome.runtime.sendMessage<IMessage<void>>({
       type: "fetch-resource",
       subtype: "credentials",
     });
     setCredentials(data.credentials);
+    setIsLoading(false);
   };
 
   const createSigninWithCredential = async (credential: any) => {
@@ -21,9 +25,10 @@ export function SelectCredential(): JSX.Element {
       },
     });
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-      chrome.tabs.sendMessage(
-        tabs[0].id!,
-        { type: "tab", subtype: "reload-state" });
+      chrome.tabs.sendMessage(tabs[0].id!, {
+        type: "tab",
+        subtype: "reload-state",
+      });
     });
     window.close();
   };
@@ -34,6 +39,11 @@ export function SelectCredential(): JSX.Element {
 
   return (
     <>
+      {isLoading ? (
+        <div className="flex flex-row justify-center items-center">
+          <Loader size={6} />
+        </div>
+      ) : null}
       {credentials.map((credential, index) => (
         <div key={index} className="my-2 mx-4">
           <div className=" relative opacity-80 hover:opacity-100">

--- a/src/components/selectIdentifier.tsx
+++ b/src/components/selectIdentifier.tsx
@@ -1,9 +1,17 @@
 import { useState, useEffect } from "react";
 import { IdentifierCard } from "@components/identifierCard";
+import { Loader } from "@components/loader";
 import { IMessage } from "@pages/background/types";
+import { Drawer } from "@components/drawer";
+import { CreateIdentifierCard } from "@components/createIdentifierCard";
 
 export function SelectIdentifier(): JSX.Element {
   const [aids, setAids] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [showDrawer, setShowDrawer] = useState(false);
+  const [errCreate, setErrCreate] = useState("");
+
   const fetchIdentifiers = async () => {
     const { data } = await chrome.runtime.sendMessage<IMessage<void>>({
       type: "fetch-resource",
@@ -23,9 +31,10 @@ export function SelectIdentifier(): JSX.Element {
     });
 
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-      chrome.tabs.sendMessage(
-        tabs[0].id!,
-        { type: "tab", subtype: "reload-state" });
+      chrome.tabs.sendMessage(tabs[0].id!, {
+        type: "tab",
+        subtype: "reload-state",
+      });
     });
     window.close();
   };
@@ -34,8 +43,52 @@ export function SelectIdentifier(): JSX.Element {
     fetchIdentifiers();
   }, []);
 
+  const handleCreateIdentifier = async (name) => {
+    setIsCreating(true);
+    const { data, error } = await chrome.runtime.sendMessage<IMessage<void>>({
+      type: "create-resource",
+      subtype: "identifier",
+      data: { name },
+    });
+    if (error) {
+      setErrCreate(error?.message);
+    } else {
+      if (data.done) {
+        const prefix = data?.name?.split(".")?.[1];
+        await createSigninWithIdentifiers({ prefix, name });
+      }
+      setErrCreate("");
+    }
+    setIsCreating(false);
+  };
+
   return (
     <>
+      {isLoading ? (
+        <div className="flex flex-row justify-center items-center">
+          <Loader size={6} />
+        </div>
+      ) : null}
+      <div className=" flex flex-row-reverse">
+        <button
+          type="button"
+          onClick={() => setShowDrawer(true)}
+          className="text-white bg-green font-medium rounded-full text-xs px-2 py-1 text-center"
+        >
+          {"+ Create New"}
+        </button>
+      </div>
+      <Drawer
+        isOpen={showDrawer}
+        handleClose={() => setShowDrawer(false)}
+        header="Create Identifier"
+      >
+        <CreateIdentifierCard
+          isLoading={isCreating}
+          handleCreateIdentifier={handleCreateIdentifier}
+          error={errCreate}
+        />
+      </Drawer>
       {aids.map((aid, index) => (
         <div key={index} className="my-2 mx-4">
           <div className=" relative opacity-80 hover:opacity-100">

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -142,7 +142,7 @@ chrome.runtime.onMessage.addListener(function (
     ) {
       try {
         const resp = await signifyService.createAID(message.data.name);
-        sendResponse({ data: { resp } });
+        sendResponse({ data: { ...(resp ?? {}) } });
       } catch (error) {
         const errorMsg = JSON.parse(error?.message ?? "");
         sendResponse({

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -137,6 +137,20 @@ chrome.runtime.onMessage.addListener(function (
       sendResponse({ data: { signins: storageSignins } });
     }
     if (
+      message.type === "create-resource" &&
+      message.subtype === "identifier"
+    ) {
+      try {
+        const resp = await signifyService.createAID(message.data.name);
+        sendResponse({ data: { resp } });
+      } catch (error) {
+        const errorMsg = JSON.parse(error?.message ?? "");
+        sendResponse({
+          error: { code: 404, message: errorMsg?.title },
+        });
+      }
+    }
+    if (
       message.type === "fetch-resource" &&
       message.subtype === "identifiers"
     ) {

--- a/src/pages/background/services/signify.ts
+++ b/src/pages/background/services/signify.ts
@@ -8,7 +8,7 @@ const Signify = () => {
   let _client: SignifyClient | null;
 
   chrome.alarms.onAlarm.addListener(async (alarm) => {
-    if (alarm.name == 'passcode-timeout') {
+    if (alarm.name == "passcode-timeout") {
       console.log("Timer expired, client and passcode zeroed out");
       _client = null;
       await userService.removePasscode();
@@ -16,23 +16,22 @@ const Signify = () => {
   });
 
   const setTimeoutAlarm = () => {
-    chrome.alarms.create('passcode-timeout', {
+    chrome.alarms.create("passcode-timeout", {
       delayInMinutes: PASSCODE_TIMEOUT,
     });
-  }
+  };
 
   const resetTimeoutAlarm = async () => {
-    await chrome.alarms.clear('passcode-timeout')
+    await chrome.alarms.clear("passcode-timeout");
     setTimeoutAlarm();
-  }
-
+  };
 
   const connect = async (url: string, passcode: string) => {
     await ready();
     _client = new SignifyClient(url, passcode, Tier.low);
     await _client.connect();
     setTimeoutAlarm();
-  }
+  };
 
   const isConnected = async () => {
     const passcode = await userService.getPasscode();
@@ -42,8 +41,12 @@ const Signify = () => {
       await resetTimeoutAlarm();
     }
 
-    console.log(_client ? "Signify client is connected" :  "Signify client is not connected");
-    return _client ? true : false
+    console.log(
+      _client
+        ? "Signify client is connected"
+        : "Signify client is not connected"
+    );
+    return _client ? true : false;
   };
 
   const validateClient = () => {
@@ -76,34 +79,35 @@ const Signify = () => {
     const keeper = _client?.manager!.get(hab);
 
     const authenticator = new Authenticater(
-        keeper.signers[0],
-        keeper.signers[0].verfer
+      keeper.signers[0],
+      keeper.signers[0].verfer
     );
 
     const headers = new Headers();
-    headers.set('Signify-Resource', hab.prefix);
+    headers.set("Signify-Resource", hab.prefix);
     headers.set(
-        'Signify-Timestamp',
-        new Date().toISOString().replace('Z', '000+00:00')
+      "Signify-Timestamp",
+      new Date().toISOString().replace("Z", "000+00:00")
     );
-    headers.set('Origin', origin);
+    headers.set("Origin", origin);
 
     const fields = [
       // '@method',
       // '@path',
-      'signify-resource',
-      'signify-timestamp',
-      'origin'
+      "signify-resource",
+      "signify-timestamp",
+      "origin",
     ];
 
-    const signed_headers = authenticator.sign(
-      headers,
-      "",
-      "",
-      fields
-    ); 
+    const signed_headers = authenticator.sign(headers, "", "", fields);
 
     return signed_headers;
+  };
+
+  const createAID = async (name: string) => {
+    validateClient();
+    let res = await _client?.identifiers().create(name);
+    return await res?.op();
   };
 
   return {
@@ -112,7 +116,8 @@ const Signify = () => {
     disconnect,
     listIdentifiers,
     listCredentials,
-    signHeaders
+    signHeaders,
+    createAID,
   };
 };
 

--- a/src/pages/background/utils.ts
+++ b/src/pages/background/utils.ts
@@ -44,3 +44,11 @@ export const obfuscateString = (inputString: string) => {
 export const removeSlash = (site:string) => {
   return site.replace(/\/$/, "");
 };
+
+export const hasWhiteSpace = (s: string) => {
+  return s.indexOf(' ') >= 0;
+}
+
+export const removeWhiteSpace = (s: string, replace="") => {
+  return s.replace(/\s/g, replace);
+}


### PR DESCRIPTION
https://github.com/WebOfTrust/signify-browser-extension/issues/76#issuecomment-1904147007

Ability to create aid from default screen and aid-selection for signing.

- [x] No whitespace allowed for the alias, do not allow the user to use whitespace.
- [x] Add some padding to the error message below the 'Create Identifier' alias box.
- [x] Fix alert list bug to display the AID properly.