### PR TITLE
Filter by schema

### DIFF
--- a/src/pages/background/services/signify.ts
+++ b/src/pages/background/services/signify.ts
@@ -2,7 +2,7 @@ import { SignifyClient, Tier, ready, Authenticater } from "signify-ts";
 import { userService } from "@pages/background/services/user";
 import { configService } from "@pages/background/services/config";
 
-const PASSCODE_TIMEOUT = 1;
+const PASSCODE_TIMEOUT = 5;
 
 const Signify = () => {
   let _client: SignifyClient | null;

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -66,7 +66,9 @@ window.addEventListener(
               (event.data.type === TAB_STATE.SELECT_CREDENTIAL ||
                 event.data.type === TAB_STATE.SELECT_ID_CRED)
             ) {
-              filteredSignins.push(signin);
+              if (!event.data.schema || signin.credential.schema.id === event.data.schema){
+                filteredSignins.push(signin);
+              }
             }
           });
 


### PR DESCRIPTION
With that change, if the web send a message of type `TAB_STATE.SELECT_CREDENTIAL` or `TAB_STATE.SELECT_ID_CRED` and add the property `schema` with the schema said, the extension will show only signings with that specific credential.

