### PR TITLE
feat: add build step for firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "vite build",
+    "build:firefox":"BROWSER=firefox vite build",
     "dev": "nodemon"
   },
   "type": "module",


### PR DESCRIPTION
https://github.com/WebOfTrust/signify-browser-extension/issues/118

run `npm run build` to create a build for chrome, destination folder: `dist/chrome`
run `npm run build:firefox` to create a build for firefox, destination folder: `dist/firefox`

