### PR TITLE
fix: add localhost support for agent and boot urls

### DIFF
--- a/src/pages/background/utils.ts
+++ b/src/pages/background/utils.ts
@@ -15,6 +15,12 @@ export const isValidUrl = (str: string) => {
   }
 };
 
+export const getBootUrl = (url: string) => {
+  return url.includes("localhost") || url.includes("127.0.0.1")
+    ? "http://127.0.0.1:3903"
+    : url;
+};
+
 export const getCurrentTab = (): Promise<chrome.tabs.Tab> => {
   return new Promise((resolve) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -4,7 +4,7 @@ import {
   WEB_APP_PERMS,
   configService,
 } from "@pages/background/services/config";
-import { isValidUrl } from "@pages/background/utils";
+import { isValidUrl, getBootUrl } from "@pages/background/utils";
 import { ThemeProvider, styled } from "styled-components";
 import { LocaleProvider } from "@src/_locales";
 import { default as defaultVendor } from "@src/config/vendor.json";
@@ -126,6 +126,7 @@ export default function Popup(): JSX.Element {
     if (!urlObject || !urlObject?.origin) return;
     setIsLoading(true);
 
+    const bootUrl = getBootUrl(urlObject.origin);
     const { data, error } = await chrome.runtime.sendMessage<
       IMessage<IBootAndConnect>
     >({
@@ -134,7 +135,7 @@ export default function Popup(): JSX.Element {
       data: {
         passcode,
         agentUrl,
-        bootUrl: urlObject.origin,
+        bootUrl,
       },
     });
 

--- a/src/screens/config/config.tsx
+++ b/src/screens/config/config.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useIntl } from "react-intl";
 import { configService } from "@pages/background/services/config";
 import { useLocale, languageCodeMap } from "@src/_locales";
-import { isValidUrl, setActionIcon } from "@pages/background/utils";
+import { isValidUrl, getBootUrl, setActionIcon } from "@pages/background/utils";
 import { Box, Button, Dropdown, Input, Text, Flex } from "@components/ui";
 
 const langMap = Object.entries(languageCodeMap).map((s) => ({
@@ -57,7 +57,8 @@ export function Config(props: any): JSX.Element {
     }
     if (urlObject && urlObject?.origin) {
       try {
-        await (await fetch(`${urlObject?.origin}/health`)).json();
+        const bootUrl = getBootUrl(urlObject.origin);
+        await (await fetch(`${bootUrl}/health`)).json();
       } catch (error) {
         setAgentUrlError(invalidAgentUrlMsg);
         return true;

--- a/src/screens/permission/permission.tsx
+++ b/src/screens/permission/permission.tsx
@@ -4,7 +4,7 @@ import {
   WEB_APP_PERMS,
   configService,
 } from "@pages/background/services/config";
-import { isValidUrl, setActionIcon } from "@pages/background/utils";
+import { isValidUrl, getBootUrl, setActionIcon } from "@pages/background/utils";
 import { Box, Card, Button, Text, Flex } from "@components/ui";
 import { IMessage } from "@config/types";
 
@@ -49,7 +49,8 @@ export function Permission({
     }
     if (urlObject && urlObject?.origin) {
       try {
-        await (await fetch(`${urlObject?.origin}/health`)).json();
+        const bootUrl = getBootUrl(urlObject.origin);
+        await (await fetch(`${bootUrl}/health`)).json();
       } catch (error) {
         return true;
       }


### PR DESCRIPTION
Add support to connect with agent running on local host.

Localhost ports:
agentUrl: http://127.0.0.1:3901
bootUrl: http://127.0.0.1:3903
health: {bootUrl}/health