### PR TITLE
fix: check signin autoSignin flag before signature headers

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -69,6 +69,7 @@ export interface ICredential {
   status: {
     et: string;
   };
+  cesr?: string;
 }
 
 export interface ISignature {

--- a/src/pages/background/handlers/resource.ts
+++ b/src/pages/background/handlers/resource.ts
@@ -32,7 +32,7 @@ export async function handleFetchSignifyHeaders({
   data,
 }: IHandler) {
   const { aidName } = data ?? {};
-  const signin = await signinResource.getDomainSigninByIssueName(url!, aidName);
+  const signin = await signinResource.getDomainSigninByIssueeName(url!, aidName);
   if (!signin?.autoSignin) {
     sendResponse({
       data: {},

--- a/src/pages/background/handlers/resource.ts
+++ b/src/pages/background/handlers/resource.ts
@@ -8,7 +8,7 @@ export async function handleFetchAutoSigninSignature({
   url,
 }: IHandler) {
   // Validate that message comes from a page that has a signin
-  const signins = await signinResource.getSigninsByDomain(url);
+  const signins = await signinResource.getDomainSignins(url);
   const autoSignin = signins?.find((signin) => signin.autoSignin);
   if (!signins?.length || !autoSignin) {
     sendResponse({
@@ -32,6 +32,14 @@ export async function handleFetchSignifyHeaders({
   data,
 }: IHandler) {
   const { aidName } = data ?? {};
+  const signin = await signinResource.getDomainSigninByIssueName(url!, aidName);
+  if (!signin?.autoSignin) {
+    sendResponse({
+      data: {},
+    });
+    return;
+  }
+
   const resp = await signifyService.signHeaders(aidName, url!);
   sendResponse({
     data: resp,
@@ -39,7 +47,7 @@ export async function handleFetchSignifyHeaders({
 }
 
 export async function handleFetchTabSignin({ sendResponse, url }: IHandler) {
-  const signins = await signinResource.getSigninsByDomain(url);
+  const signins = await signinResource.getDomainSignins(url);
   const autoSigninObj = signins?.find((signin) => signin.autoSignin);
   sendResponse({ data: { signins: signins ?? [], autoSigninObj } });
 }
@@ -130,7 +138,7 @@ export async function handleCreateSignin({ sendResponse, data }: IHandler) {
 }
 
 export async function handleUpdateAutoSignin({ sendResponse, data }: IHandler) {
-  const resp = await signinResource.updateAutoSigninByDomain(data?.signin);
+  const resp = await signinResource.updateDomainAutoSignin(data?.signin);
   sendResponse({
     data: {
       ...resp,

--- a/src/pages/background/resource/headers/index.ts
+++ b/src/pages/background/resource/headers/index.ts
@@ -1,22 +1,20 @@
 import browser from "webextension-polyfill";
+import { getDomainSigninByIssueName } from "@pages/background/resource/signin";
 import { signifyService } from "@pages/background/services/signify";
 
 export const getSignifyHeaders = async (
   url: string,
   headers?: browser.WebRequest.HttpHeaders
 ) => {
-  const xAppendSignifyHeader = headers?.find(
-    (header) => header.name === "x-append-signify-headers"
-  );
   const xAidName = headers?.find((header) => header.name === "x-aid-name");
 
-  if (xAppendSignifyHeader?.value === "true" && xAidName?.value) {
+  if (xAidName?.value) {
+    const signin = await getDomainSigninByIssueName(url, xAidName?.value);
+    if (!signin?.autoSignin) {
+      return headers;
+    }
     const resp = await signifyService.signHeaders(xAidName?.value, url!);
-    headers = headers?.filter(
-      (header) =>
-        header.name !== "x-aid-name" &&
-        header.name !== "x-append-signify-headers"
-    );
+    headers = headers?.filter((header) => header.name !== "x-aid-name");
     Object.entries(resp).forEach((entry) => {
       headers?.push({ name: entry[0], value: entry[1] });
     });

--- a/src/pages/background/resource/headers/index.ts
+++ b/src/pages/background/resource/headers/index.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import { getDomainSigninByIssueName } from "@pages/background/resource/signin";
+import { getDomainSigninByIssueeName } from "@pages/background/resource/signin";
 import { signifyService } from "@pages/background/services/signify";
 
 export const getSignifyHeaders = async (
@@ -9,7 +9,7 @@ export const getSignifyHeaders = async (
   const xAidName = headers?.find((header) => header.name === "x-aid-name");
 
   if (xAidName?.value) {
-    const signin = await getDomainSigninByIssueName(url, xAidName?.value);
+    const signin = await getDomainSigninByIssueeName(url, xAidName?.value);
     if (!signin?.autoSignin) {
       return headers;
     }

--- a/src/pages/background/resource/signin/index.ts
+++ b/src/pages/background/resource/signin/index.ts
@@ -31,7 +31,7 @@ export const updateSignins = async (signins: ISignin[]) => {
   await browserStorageService.setValue("signins", signinsObj);
 };
 
-export const getSigninsByDomain = async (url?: string) => {
+export const getDomainSignins = async (url?: string) => {
   if (!url) return [];
 
   const domain = getDomainFromUrl(url);
@@ -39,7 +39,19 @@ export const getSigninsByDomain = async (url?: string) => {
   return signins?.filter((signin) => signin.domain === domain);
 };
 
-export const updateAutoSigninByDomain = async (signin: ISignin) => {
+export const getDomainSigninByIssueName = async (
+  url: string,
+  aidName: string
+) => {
+  const signins = await getDomainSignins(url);
+  return signins?.find(
+    (signin) =>
+      signin.identifier?.name === aidName ||
+      signin.credential?.issueeName === aidName
+  );
+};
+
+export const updateDomainAutoSignin = async (signin: ISignin) => {
   let signins = await getSignins();
   if (signins?.length) {
     const newSignins = signins.map((_ele) => {

--- a/src/pages/background/resource/signin/index.ts
+++ b/src/pages/background/resource/signin/index.ts
@@ -39,7 +39,7 @@ export const getDomainSignins = async (url?: string) => {
   return signins?.filter((signin) => signin.domain === domain);
 };
 
-export const getDomainSigninByIssueName = async (
+export const getDomainSigninByIssueeName = async (
   url: string,
   aidName: string
 ) => {

--- a/src/pages/background/services/signify.ts
+++ b/src/pages/background/services/signify.ts
@@ -135,6 +135,16 @@ const Signify = () => {
     return await _client?.credentials().list();
   };
 
+  // credential identifier => credential.sad.d
+  const getCredentialWithCESR = async (credentialIdentifier: string) => {
+    validateClient();
+    try {
+      return await _client?.credentials().get(credentialIdentifier, true);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   const disconnect = async () => {
     _client = null;
     await userService.removeControllerId();
@@ -189,12 +199,17 @@ const Signify = () => {
         : signin.credential?.issueeName,
       origin
     );
-  
+
+    if (signin.credential) {
+      const cesr = await getCredentialWithCESR(signin.credential?.sad?.d);
+      signin.credential.cesr = cesr;
+    }
+
     return {
       headers: signedHeaders,
       credential: signin?.credential,
       identifier: signin?.identifier,
-      autoSignin: signin?.autoSignin
+      autoSignin: signin?.autoSignin,
     };
   };
 


### PR DESCRIPTION
@rodolfomiranda pointed out a critical bug where before providing signatures we were not checking if autoSignin was true for the provided aid/credential or not. This PR fixes that.
Relevant Comment: https://github.com/WebOfTrust/signify-browser-extension/pull/171#discussion_r1588332747