### PR TITLE
fix: remove trailing slash from agent and boot url

### DIFF
--- a/src/components/ui/input/input.tsx
+++ b/src/components/ui/input/input.tsx
@@ -44,6 +44,7 @@ const StyledInputError = styled.p`
   color: ${({ theme }) => theme?.colors?.error};
   font-size: 12px;
   margin: 0;
+  overflow-wrap: break-word;
 `;
 
 export const Input = ({

--- a/src/pages/background/services/config.ts
+++ b/src/pages/background/services/config.ts
@@ -1,5 +1,6 @@
 import { browserStorageService } from "@pages/background/services/browser-storage";
 import { default as defaultVendor } from "@src/config/vendor.json";
+import { removeSlash } from "@shared/utils";
 
 const CONFIG_ENUMS = {
   VENDOR_URL: "vendor-url",
@@ -63,7 +64,10 @@ const Config = () => {
   };
 
   const setBootUrl = async (token: string) => {
-    await browserStorageService.setValue(CONFIG_ENUMS.BOOT_URL, token);
+    await browserStorageService.setValue(
+      CONFIG_ENUMS.BOOT_URL,
+      removeSlash(token)
+    );
   };
 
   const getBootUrl = async (): Promise<string> => {
@@ -73,7 +77,10 @@ const Config = () => {
   };
 
   const setAgentUrl = async (token: string) => {
-    await browserStorageService.setValue(CONFIG_ENUMS.AGENT_URL, token);
+    await browserStorageService.setValue(
+      CONFIG_ENUMS.AGENT_URL,
+      removeSlash(token)
+    );
   };
 
   const getHasOnboarded = async () => {

--- a/src/pages/background/services/session.ts
+++ b/src/pages/background/services/session.ts
@@ -2,7 +2,7 @@ import { browserStorageService } from "@pages/background/services/browser-storag
 import { ObjectOfObject, ISession } from "@config/types";
 
 const SESSION_ENUMS = {
-  EXPIRY_IN_MINS: 5,
+  EXPIRY_IN_MINS: 30,
   SESSIONS: "sessions",
 };
 


### PR DESCRIPTION
Trailing slash in agent url was appending double slashs and failing the api call

**Nord Vlei extension**
<img width="1182" alt="Screenshot 2024-08-07 at 2 44 35 AM" src="https://github.com/user-attachments/assets/25ed0324-f5a8-4b72-b1df-840618f65d00">

**Signify Extension**
<img width="1182" alt="Screenshot 2024-08-07 at 1 43 01 AM" src="https://github.com/user-attachments/assets/b58d8e6d-a77e-4e9b-8870-7069dfd05634">

[Relevant Reg Pilot Issue](https://github.com/GLEIF-IT/reg-pilot-webapp/issues/86)