### PR TITLE
fix: keep sw activated during session

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -9,6 +9,12 @@ console.log("Background script loaded");
 
 const csHandler = initCSHandler();
 const uiHandler = initUIHandler();
+const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
+function saveTimestamp() {
+  const timestamp = new Date().toISOString();
+
+  browser.storage.session.set({ timestamp });
+}
 
 browser.runtime.onStartup.addListener(function () {
   (async () => {
@@ -86,3 +92,9 @@ browser.runtime.onMessage.addListener(function (
 //   // return true to indicate chrome api to send a response asynchronously
 //   return true;
 // });
+
+async function initBackground() {
+  saveTimestamp();
+  setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
+}
+initBackground();


### PR DESCRIPTION
Service worker in manifest version 3 gets inactive if there is no activity for some time.
This causes a glitch in signify at certain points in workflow

[Signify Client not connected](https://www.loom.com/share/7e4872f6b6cf4db3951309a9ac02f36e?sid=3ae1e26b-2a78-4493-a053-cdb0b28c5c16)

To cure this, an interval is added that keeps service worker activated during the session. 
[SW activated](https://www.loom.com/share/a7c328026b2946798d5aa6c432aad4d9)

This ensures that communication with content script and service worker does not get blocked due to a pause.
