### PR TITLE
Fixed spelling of extension in log message

### DIFF
--- a/src/pages/background/services/signify.ts
+++ b/src/pages/background/services/signify.ts
@@ -36,7 +36,7 @@ const Signify = () => {
           type: SW_EVENTS.check_popup_open,
         });
         if (response.data.isOpened) {
-          console.log("Timer expired, but extsenion is open. Resetting timer.");
+          console.log("Timer expired, but extension is open. Resetting timer.");
           resetTimeoutAlarm();
         }
       } catch (error) {


### PR DESCRIPTION
Not sure how to run tests but this shouldn't break anything I think.