### PR TITLE
feat: move passcode to session storage from local

### DIFF
--- a/src/components/selectCredential.tsx
+++ b/src/components/selectCredential.tsx
@@ -22,7 +22,8 @@ export function SelectCredential(): JSX.Element {
     if (error) {
       toast.error(error?.message);
     } else {
-      const _credentials = data?.credentials?.filter(_cred => _cred.issueeName) ?? [];
+      const _credentials =
+        data?.credentials?.filter((_cred) => _cred.issueeName) ?? [];
       setCredentials(_credentials);
     }
   };
@@ -83,7 +84,9 @@ export function SelectCredential(): JSX.Element {
                   </span>
                   <ReactTooltip id={credential?.sad?.d} delayShow={200}>
                     <Flex flexDirection="row" fontSize={0} $flexGap={1}>
-                      <Text $color="">{formatMessage({ id: "credential.unidentifiedIssuee" })}</Text>
+                      <Text $color="">
+                        {formatMessage({ id: "credential.unidentifiedIssuee" })}
+                      </Text>
                     </Flex>
                   </ReactTooltip>
                 </>
@@ -92,6 +95,13 @@ export function SelectCredential(): JSX.Element {
           </Box>
         </Box>
       ))}
+      {!isLoading && !credentials?.length ? (
+        <Text fontSize={0} $color="subtext">
+          {formatMessage({ id: "message.noItems" })}
+        </Text>
+      ) : (
+        <></>
+      )}
     </>
   );
 }

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -1,5 +1,6 @@
 import browser from "webextension-polyfill";
 import { configService } from "@pages/background/services/config";
+import { sessionStorageService } from "@pages/background/services/browser-storage";
 import { IMessage } from "@config/types";
 import { senderIsPopup } from "@pages/background/utils";
 import { setActionIcon } from "@shared/browser/action-utils";
@@ -13,7 +14,7 @@ const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
 function saveTimestamp() {
   const timestamp = new Date().toISOString();
 
-  browser.storage.session.set({ timestamp });
+  sessionStorageService.setValue("timestamp", timestamp);
 }
 
 browser.runtime.onStartup.addListener(function () {
@@ -32,7 +33,6 @@ browser.runtime.onInstalled.addListener(function (object) {
     console.log("Signify Browser Extension installed");
   }
 });
-
 
 // Listener to handle internal messages from content scripts from active tab and popup
 browser.runtime.onMessage.addListener(function (

--- a/src/pages/background/services/browser-storage.ts
+++ b/src/pages/background/services/browser-storage.ts
@@ -1,4 +1,4 @@
-import browser from "webextension-polyfill";
+import browser, { Storage } from "webextension-polyfill";
 
 export const getSyncStorage = () => {
   return browser.storage.sync;
@@ -8,7 +8,11 @@ export const getNonSyncStorage = () => {
   return browser.storage.local;
 };
 
-const BrowserStorage = (storage = getNonSyncStorage()) => {
+export const getSessionStorage = () => {
+  return browser.storage.session;
+};
+
+const BrowserStorage = (storage: Storage.StorageArea) => {
   const _storage = storage;
 
   const getAllKeys = async () => {
@@ -43,4 +47,5 @@ const BrowserStorage = (storage = getNonSyncStorage()) => {
   };
 };
 
-export const browserStorageService = BrowserStorage();
+export const browserStorageService = BrowserStorage(getNonSyncStorage());
+export const sessionStorageService = BrowserStorage(getSessionStorage());

--- a/src/pages/background/services/user.ts
+++ b/src/pages/background/services/user.ts
@@ -1,4 +1,4 @@
-import { browserStorageService } from "@pages/background/services/browser-storage";
+import { sessionStorageService } from "@pages/background/services/browser-storage";
 
 const USER_ENUMS = {
   PASSCODE: "user-passcode",
@@ -7,31 +7,31 @@ const USER_ENUMS = {
 
 const User = () => {
   const getPasscode = async (): Promise<string> => {
-    return (await browserStorageService.getValue(
+    return (await sessionStorageService.getValue(
       USER_ENUMS.PASSCODE
     )) as string;
   };
 
   const removePasscode = async () => {
-    await browserStorageService.removeKey(USER_ENUMS.PASSCODE);
+    await sessionStorageService.removeKey(USER_ENUMS.PASSCODE);
   };
 
   const setPasscode = async (passcode: string) => {
-    await browserStorageService.setValue(USER_ENUMS.PASSCODE, passcode);
+    await sessionStorageService.setValue(USER_ENUMS.PASSCODE, passcode);
   };
 
   const getControllerId = async (): Promise<string> => {
-    return (await browserStorageService.getValue(
+    return (await sessionStorageService.getValue(
       USER_ENUMS.CONTROLLER_ID
     )) as string;
   };
 
   const removeControllerId = async () => {
-    await browserStorageService.removeKey(USER_ENUMS.CONTROLLER_ID);
+    await sessionStorageService.removeKey(USER_ENUMS.CONTROLLER_ID);
   };
 
   const setControllerId = async (controllerId: string) => {
-    await browserStorageService.setValue(
+    await sessionStorageService.setValue(
       USER_ENUMS.CONTROLLER_ID,
       controllerId
     );


### PR DESCRIPTION
**Linked Issue:** https://github.com/WebOfTrust/signify-browser-extension/issues/218

**Problem:**
passcode is stored in the browser extension's local storage, which raises security issues and can be sneak peaked using multiple plugins.

passcode and other user related info e.g controlled ID are moved to session storage. 

**Behaviour Change**
Earlier, if extension was unlocked it remained unlocked until timeout occurred. It means even if browser is closed and reopened before the timeout, extension remained unlocked.

Now extension moves to a locked state whenever the user closes the browser or timeout reaches.
