### PR TITLE
chore: pin SignifyTS version to 0.3.0-rc1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react-hot-toast": "^2.4.1",
         "react-intl": "^6.6.2",
         "react-tooltip": "^5.26.2",
-        "signify-ts": "github:WebOfTrust/signify-ts",
+        "signify-ts": "0.3.0-rc1",
         "styled-components": "^6.1.8",
         "styled-system": "^5.1.5",
         "webextension-polyfill": "^0.10.0"
@@ -7390,8 +7390,9 @@
       "dev": true
     },
     "node_modules/signify-ts": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WebOfTrust/signify-ts.git#6113497b1ef73b6c6cb0b4ca3c688313116f02da",
+      "version": "0.3.0-rc1",
+      "resolved": "https://registry.npmjs.org/signify-ts/-/signify-ts-0.3.0-rc1.tgz",
+      "integrity": "sha512-mCEt+Dn2l8fzFLePYd+MuBnbht9NhUj3B5NE9NYRhxtFpP+0E/78E8fb6rDwMC9qsRrI9/HX4Jpayt8juR4M2Q==",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"
@@ -8081,7 +8082,7 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-hot-toast": "^2.4.1",
     "react-intl": "^6.6.2",
     "react-tooltip": "^5.26.2",
-    "signify-ts": "github:WebOfTrust/signify-ts",
+    "signify-ts": "0.3.0-rc1",
     "styled-components": "^6.1.8",
     "styled-system": "^5.1.5",
     "webextension-polyfill": "^0.10.0"


### PR DESCRIPTION
This pins the SignifyTS version to the specific 0.3.0-rc1 version of SignifyTS rather than to a versionless `github:WebOfTrust/signify-ts` dependency specification.